### PR TITLE
Update Packages-Desktop

### DIFF
--- a/community/deepin/Packages-Desktop
+++ b/community/deepin/Packages-Desktop
@@ -32,7 +32,6 @@ gimp
 gksu
 gnome-system-monitor
 gnome-terminal
-gnome-vfs
 gparted
 gst-libav
 gst-plugins-bad


### PR DESCRIPTION
Remove gnome-vfs, as it seems to be no longer available. This causes build to fail.