### PR TITLE
remove gnome keyring

### DIFF
--- a/community/budgie/Packages-Desktop
+++ b/community/budgie/Packages-Desktop
@@ -19,7 +19,6 @@ gnome-calculator
 gnome-control-center
 gnome-disk-utility
 gnome-font-viewer
-gnome-keyring
 gnome-settings-daemon
 gnome-system-log
 gnome-system-monitor


### PR DESCRIPTION
remove gnome keyring because password request with google-chrome.