### PR TITLE
Update Packages-Desktop (`mate-system-monitor` and `>extra mate-tweak`)

### DIFF
--- a/community/mate/Packages-Desktop
+++ b/community/mate/Packages-Desktop
@@ -27,6 +27,7 @@ mate-utils
 mate-notification-daemon
 mate-media
 mate-user-guide
+mate-system-monitor
 pluma
 gnome-disk-utility
 gnome-keyring
@@ -122,6 +123,7 @@ yelp
 >extra gtk3-print-backends
 >extra manjaro-documentation
 >extra mate-themes
+>extra mate-tweak
 >extra libreoffice-fresh
 >extra thunderbird
 >extra lollypop


### PR DESCRIPTION
Mate system monitor isn't included in the live cd and it's really useful. It also has a tab `About` which many users (and youtubers) use it to see the current MATE version before they install it.

I think mate-tweak should be included in the full installation. It is useful, especially for the new users.