### PR TITLE
Lxde Package-Desktop: Add manjaro-printer

### DIFF
--- a/community/lxde/Packages-Desktop
+++ b/community/lxde/Packages-Desktop
@@ -161,20 +161,13 @@ manjaro-hotfixes
 >extra jre8-openjdk
 
 ## Printing
->extra cups
->extra cups-pdf
->extra cups-pk-helper
->extra ghostscript
->extra gsfonts
+>extra manjaro-printer
 >extra gtk3-print-backends
->extra hplip
->extra splix
 
 ## Optional dependencies for hplip
 >extra pyqt5-common # For hplip
 >extra python-pillow # For hplip
 >extra python-pip # For hplip
->extra python-pyqt5  # For hplip gui
 >extra python-reportlab # For hplip
 
 ## Games


### PR DESCRIPTION
I saw that **system-config-printer** was missing from the **## Printing** section at **Packages-Desktop** (I initially copy the file from xfce's profile Packages-Desktop). So, I decided to include the **manjaro-printer** package which includes it as dependency. Then, I removed the other manjaro-printer's dependencies in order to clean the Packages-Desktop.