### PR TITLE
LXDE: Restructure Packages-Desktop (getting ready for netgroups)

### DIFF
--- a/community/lxde/Packages-Desktop
+++ b/community/lxde/Packages-Desktop
@@ -118,6 +118,7 @@ firefox
 hexchat
 epdfview
 gpicview
+galculator-gtk2
 
 # Optional dependencies engrampa
 p7zip  # 7Z and ARJ archive support
@@ -192,7 +193,6 @@ manjaro-hotfixes
 >extra guvcview
 >extra gnome-disk-utility
 >extra transmission-gtk
->extra galculator-gtk2
 >extra gimp
 >extra libreoffice-fresh
 >extra mlocate

--- a/community/lxde/Packages-Desktop
+++ b/community/lxde/Packages-Desktop
@@ -59,10 +59,9 @@ make
 patch
 pkg-config
 >multilib lib32-flex
-# Extra packages for AUR support
->extra git
->extra patchutils
->extra subversion
+git
+patchutils
+subversion
 
 ## Display manager
 lightdm

--- a/community/lxde/Packages-Desktop
+++ b/community/lxde/Packages-Desktop
@@ -155,6 +155,8 @@ xdg-su
 ## Misc
 manjaro-hotfixes
 
+##### EXTRA - TO BE INCLUDED IN NETGROUPS #####
+
 ## Java
 >extra jdk8-openjdk
 >extra jre8-openjdk-headless
@@ -179,8 +181,10 @@ manjaro-hotfixes
 >extra ttf-liberation
 >extra ttf-droid
 
-## Extra Applications
+## Extra Themes/Artwork
 >extra manjaro-wallpapers-17.0
+
+## Extra Applications
 >extra gufw
 >extra powertop
 >extra htop

--- a/community/lxde/Packages-Desktop
+++ b/community/lxde/Packages-Desktop
@@ -118,7 +118,6 @@ hexchat
 epdfview
 gpicview
 galculator-gtk2
-menulibre
 
 # Optional dependencies engrampa
 p7zip  # 7Z and ARJ archive support
@@ -203,3 +202,4 @@ manjaro-hotfixes
 >extra thunderbird
 >extra xfburn
 >extra yelp
+>extra menulibre

--- a/community/lxde/Packages-Desktop
+++ b/community/lxde/Packages-Desktop
@@ -163,16 +163,13 @@ manjaro-hotfixes
 >extra jre8-openjdk-headless
 >extra jre8-openjdk
 
-## Printing
+## Printing Support
 >extra manjaro-printer
 >extra gtk3-print-backends
 >extra pyqt5-common # For hplip
 >extra python-pillow # For hplip
 >extra python-pip # For hplip
 >extra python-reportlab # For hplip
-
-## Games
->extra steam-manjaro
 
 ## Extra Fonts
 >extra terminus-font
@@ -189,6 +186,9 @@ manjaro-hotfixes
 >extra powertop
 >extra htop
 >extra mlocate
+
+## Games
+>extra steam-manjaro
 
 ## Extra Applications
 >extra gufw

--- a/community/lxde/Packages-Desktop
+++ b/community/lxde/Packages-Desktop
@@ -97,7 +97,6 @@ gnome-keyring      # fix wlan segfault
 libgsf             # tumbler - for ODF thumbnails
 libopenraw         # tumbler - for RAW thumbnails
 network-manager-applet
-menulibre
 >systemd pavucontrol
 manjaro-lxde-settings
 gnome-icon-theme
@@ -119,6 +118,7 @@ hexchat
 epdfview
 gpicview
 galculator-gtk2
+menulibre
 
 # Optional dependencies engrampa
 p7zip  # 7Z and ARJ archive support
@@ -186,16 +186,18 @@ manjaro-hotfixes
 ## Extra Themes/Artwork
 >extra manjaro-wallpapers-17.0
 
-## Extra Applications
->extra gufw
+## Extra Cli Applications
 >extra powertop
 >extra htop
+>extra mlocate
+
+## Extra Applications
+>extra gufw
 >extra guvcview
 >extra gnome-disk-utility
 >extra transmission-gtk
 >extra gimp
 >extra libreoffice-fresh
->extra mlocate
 >extra pidgin
 >extra vlc-nightly
 >extra thunderbird

--- a/community/lxde/Packages-Desktop
+++ b/community/lxde/Packages-Desktop
@@ -117,6 +117,7 @@ scrot
 firefox
 hexchat
 epdfview
+gpicview
 
 # Optional dependencies engrampa
 p7zip  # 7Z and ARJ archive support
@@ -198,6 +199,5 @@ manjaro-hotfixes
 >extra pidgin
 >extra vlc-nightly
 >extra thunderbird
->extra gpicview
 >extra xfburn
 >extra yelp

--- a/community/lxde/Packages-Desktop
+++ b/community/lxde/Packages-Desktop
@@ -99,14 +99,11 @@ libopenraw         # tumbler - for RAW thumbnails
 network-manager-applet
 menulibre
 >systemd pavucontrol
-
 manjaro-lxde-settings
-
-## More Themes QT/GTK/SDDM
 gnome-icon-theme
 gnome-themes-standard
 
-## Applications
+## Basic Applications
 manjaro-hello
 manjaro-settings-manager
 manjaro-settings-manager-notifier
@@ -116,6 +113,7 @@ inxi
 dmidecode # optional dependency inxi
 leafpad
 scrot
+firefox
 
 # Optional dependencies engrampa
 p7zip  # 7Z and ARJ archive support
@@ -188,7 +186,6 @@ manjaro-hotfixes
 >extra guvcview
 >extra gnome-disk-utility
 >extra transmission-gtk
->extra firefox
 >extra galculator-gtk2
 >extra gimp
 >extra hexchat

--- a/community/lxde/Packages-Desktop
+++ b/community/lxde/Packages-Desktop
@@ -102,6 +102,7 @@ menulibre
 manjaro-lxde-settings
 gnome-icon-theme
 gnome-themes-standard
+poppler-data   #CKJ support for pdf
 
 ## Basic Applications
 manjaro-hello
@@ -114,6 +115,8 @@ dmidecode # optional dependency inxi
 leafpad
 scrot
 firefox
+hexchat
+epdfview
 
 # Optional dependencies engrampa
 p7zip  # 7Z and ARJ archive support
@@ -160,8 +163,6 @@ manjaro-hotfixes
 ## Printing
 >extra manjaro-printer
 >extra gtk3-print-backends
-
-## Optional dependencies for hplip
 >extra pyqt5-common # For hplip
 >extra python-pillow # For hplip
 >extra python-pip # For hplip
@@ -188,12 +189,9 @@ manjaro-hotfixes
 >extra transmission-gtk
 >extra galculator-gtk2
 >extra gimp
->extra hexchat
->extra epdfview
 >extra libreoffice-fresh
 >extra mlocate
 >extra pidgin
->extra poppler-data   #CKJ support for pdf
 >extra vlc-nightly
 >extra thunderbird
 >extra gpicview


### PR DESCRIPTION
I'm planning to switch the lxde install to a netinstall similar to MATE edition (**netinstall="true"** and **chrootcfg="false"**). No packages were added/removed. I only moved some of them from/to extra in order to get ready for Calamares Netgroups. I also added some comments in order to see what purpose each package serves, more easily.

The next step will be to make a pull request in order to add **packages-systemd.yaml** to calamares-netgroups in order to be able to test how this looks (right now I cannot test since Calamares is looking for net packages from github and there aren't any existing for lxde profile right now).

After this is finished and all looks good, I will change accordingly the **profile.conf** in order to enable netinstall.