### PR TITLE
LXDE: Enable touchpad tap-to-click by default

### DIFF
--- a/community/lxde/desktop-overlay/etc/X11/xorg.conf.d/70-synaptics.conf
+++ b/community/lxde/desktop-overlay/etc/X11/xorg.conf.d/70-synaptics.conf
@@ -1,0 +1,39 @@
+Section "InputClass"
+    Identifier "touchpad"
+    Driver "synaptics"
+    MatchIsTouchpad "on"
+        Option "TapButton1" "1"
+        Option "TapButton2" "3"
+        Option "TapButton3" "2"
+        Option "VertEdgeScroll" "on"
+        Option "HorizEdgeScroll" "on"
+        Option "SingleTapTimeout" "10"
+EndSection
+
+Section "InputClass"
+        Identifier "touchpad ignore duplicates"
+        MatchIsTouchpad "on"
+        MatchOS "Linux"
+        MatchDevicePath "/dev/input/mouse*"
+        Option "Ignore" "on"
+EndSection
+
+# This option enables the bottom right corner to be a right button on clickpads
+# and the right and middle top areas to be right / middle buttons on clickpads
+# with a top button area.
+# This option is only interpreted by clickpads.
+Section "InputClass"
+        Identifier "Default clickpad buttons"
+        MatchDriver "synaptics"
+        Option "SoftButtonAreas" "50% 0 82% 0 0 0 0 0"
+        Option "SecondarySoftButtonAreas" "58% 0 0 15% 42% 58% 0 15%"
+EndSection
+
+# This option disables software buttons on Apple touchpads.
+# This option is only interpreted by clickpads.
+Section "InputClass"
+        Identifier "Disable clickpad buttons on Apple touchpads"
+        MatchProduct "Apple|bcm5974"
+        MatchDriver "synaptics"
+        Option "SoftButtonAreas" "0 0 0 0 0 0 0 0"
+EndSection


### PR DESCRIPTION
This is needed in order to enable tap-to-click by default on touchpads. I've only changed the 1st section (**Section "InputClass"**, **Identifier "touchpad"**, **Driver "synaptics"**). The rest are copied from **/usr/share/X11/xorg.conf.d/70-synaptics.conf** as it is advised in the comments in that file. Since, **/etc/X11/xorg.conf.d/70-synaptics.conf**  settings override the settings of the other file (which is owned by **xf86-input-synaptics**), the rest settings will be lost if I didn't copied them along and I'm not sure if they are useful or not so I didn't want to mess with that.