### PR TITLE
Enable netinstall for lxde profile

### DIFF
--- a/community/lxde/profile.conf
+++ b/community/lxde/profile.conf
@@ -14,7 +14,7 @@ displaymanager="lightdm"
 # nonfree_mhwd="true"
 
 # use extra packages as defined in pkglist to activate a full profile
-extra="true"
+extra="false"
 
 ################ install ################
 
@@ -22,7 +22,7 @@ extra="true"
 # efi_boot_loader="grub"
 
 # configure calamares for netinstall
-# netinstall="false"
+netinstall="true"
 
 # configure calamares to use chrootcfg instead of unpackfs
 # chrootcfg="false"


### PR DESCRIPTION
I've done several tests and all seem ok. So, I enable netinstall by default for the lxde profile.