### PR TITLE
Lxde Packages-Desktop: Yaourt to base installation. Comply with netgroups.

### DIFF
--- a/community/lxde/Packages-Desktop
+++ b/community/lxde/Packages-Desktop
@@ -62,6 +62,7 @@ pkg-config
 git
 patchutils
 subversion
+yaourt
 
 ## Display manager
 lightdm
@@ -171,6 +172,9 @@ manjaro-hotfixes
 >extra python-pip # For hplip
 >extra python-reportlab # For hplip
 
+## Scanner Support
+>extra simple-scan
+
 ## Extra Fonts
 >extra terminus-font
 >extra ttf-bitstream-vera
@@ -183,6 +187,8 @@ manjaro-hotfixes
 >extra manjaro-wallpapers-17.0
 
 ## Extra Cli Applications
+>extra pacui
+>extra mhwd-tui
 >extra powertop
 >extra htop
 >extra mlocate


### PR DESCRIPTION
 1. I added yaourt to base installation since it's really useful tool and I want the users to have full AUR support by default

 2. I added some **>extra** software in order to keep **Packages-Desktop** in agreement with **packages-systemd.yaml** from lxde netgroup, in case someone (or me in the future) wants to do manually a full profile build.