### PR TITLE
lxde: Shall I delete the /etc/fonts/conf.d/70-no-bitmaps.conf symbolic link?

### DIFF
--- a/community/lxde/desktop-overlay/etc/fonts/conf.d/70-no-bitmaps.conf
+++ b/community/lxde/desktop-overlay/etc/fonts/conf.d/70-no-bitmaps.conf
@@ -1,1 +1,0 @@
-/etc/fonts/conf.avail/70-no-bitmaps.conf


### PR DESCRIPTION
I just did a manjaro architect installation by choosing lxde, which doesn't include the **desktop-overlay** files (if I have understood correctly how it works), and I noticed that **/etc/fonts/conf.d/70-no-bitmaps.conf** symbolic link already exists. I also noticed that the only edition which still includes it in the **desktop-overlay** folder, is the xfce one.

So, is it still needed? Or did it used to be needed but no any more and I can safely remove it?