### PR TITLE
adopt to xorg-pkg changes similar to the official manjaro editions

### DIFF
--- a/community/lxde/Packages-Desktop
+++ b/community/lxde/Packages-Desktop
@@ -142,9 +142,7 @@ numlockx
 mesa-demos
 >multilib lib32-mesa-demos
 xorg-server
-xorg-server-utils
 xorg-twm
-xorg-utils
 xorg-xinit
 xorg-xkill
 


### PR DESCRIPTION
If I understood correctly the latest commit on the official manjaro editions, then these packages are not needed anymore.