### PR TITLE
lxde: include manjaro-lxde-xfce4-notifyd in Packages-Desktop

### DIFF
--- a/community/lxde/Packages-Desktop
+++ b/community/lxde/Packages-Desktop
@@ -84,6 +84,7 @@ lxterminal
 pcmanfm
 
 ## Essential stuff for good LXDE experience
+manjaro-lxde-xfce4-notifyd
 xfce4-power-manager
 light-locker
 cantarell-fonts


### PR DESCRIPTION
The only reason I have included it on **manjaro-lxde-settings** is because I hadn't included it in the ISO before and I wanted the current users to get it too. However, xfce4-notifyd isn't really needed for manjaro-lxde-settings and I want users to be able to remove it and use some daemon (like dunst) if they want to, without losing manjaro-lxde-settings. So, after the next release (or the one after that in order to be sure that no one is using the old ISO) I will remove it from manjaro-lxde-settings dependencies.