### PR TITLE
Add postlogin script to gdm for gnome profile

### DIFF
--- a/manjaro/gnome/desktop-overlay/etc/gdm/PostLogin/Default
+++ b/manjaro/gnome/desktop-overlay/etc/gdm/PostLogin/Default
@@ -1,0 +1,2 @@
+#!/bin/sh
+grep -q "^AutomaticLoginEnable=True" /etc/gdm/custom.conf || pkill -KILL -u gdm


### PR DESCRIPTION
Kill the gdm user processess IF autologin is not enabled