### PR TITLE
MATE: remove galculator (mate-calc is already included)

### DIFF
--- a/community/mate/Packages-Desktop
+++ b/community/mate/Packages-Desktop
@@ -15,7 +15,6 @@ manjaro-wallpapers-17.0
 mate-icon-theme
 xcursor-breeze
 mate
-galculator
 marco
 brisk-menu
 mate-notification-theme-slate


### PR DESCRIPTION
@Ste74  I've noticed that you have included both **mate-calc** and **galculator**. I'm guessing that you only want **mate-calc**.