### PR TITLE
Replace vlc-nightly with vlc release in kde and xfce

### DIFF
--- a/manjaro/kde/Packages-Desktop
+++ b/manjaro/kde/Packages-Desktop
@@ -233,7 +233,7 @@ sshfs  # remote filesystem browser
 >extra dvdauthor        # for creation of DVD
 >extra dvgrab           # for firewire capture
 >extra recordmydesktop  # for screen capture
-#>extra vlc-nightly     # for DVD preview, needs xine-ui or vlc, vlc is in "Applications" section
+#>extra vlc             # for DVD preview, needs xine-ui or vlc, vlc is in "Applications" section
 >extra movit            # for GPU video processing
 
 ## Optional dependencies for okular
@@ -262,7 +262,7 @@ powertop
 screenfetch
 >systemd systemd-kcm
 >extra thunderbird-kde
-vlc-nightly
+vlc
 yakuake
 
 ## Optional dependencis for cantata

--- a/manjaro/xfce/Packages-Desktop
+++ b/manjaro/xfce/Packages-Desktop
@@ -223,7 +223,7 @@ powertop
 >extra poppler-data  # CKJ support for pdf
 >basic sylpheed # mail client
 >extra thunderbird
->extra vlc-nightly
+>extra vlc
 >extra viewnior
 >extra xfburn
 >extra yelp


### PR DESCRIPTION
No user expects nightly builds of a program on their desktop by default;
there's no guarantee it will even open. Release is used in the lxqt profile, so this was previously inconsistent too.