### PR TITLE
[Cinnamon] Add missing VPN packages

### DIFF
--- a/community/cinnamon/Packages-Desktop
+++ b/community/cinnamon/Packages-Desktop
@@ -72,7 +72,11 @@ manjaro-settings-manager-notifier
 >extra nemo-share
 netctl
 networkmanager-dispatcher-ntpd
+networkmanager-openconnect
 >openrc networkmanager-openrc
+networkmanager-openvpn
+networkmanager-pptp
+networkmanager-vpnc
 >extra npapi-vlc
 nss-mdns
 ntp


### PR DESCRIPTION
This adds VPN packages to Cinnamon which already exists in at least Xfce, Gnome, KDE, and Mate editions.