### PR TITLE
[bspwm] Add missing VPN packages

### DIFF
--- a/community/bspwm/Packages-Desktop
+++ b/community/bspwm/Packages-Desktop
@@ -53,6 +53,10 @@ ncdu
 networkmanager
 networkmanager-dispatcher-ntpd
 networkmanager-dmenu
+networkmanager-openconnect
+networkmanager-openvpn
+networkmanager-pptp
+networkmanager-vpnc
 openresolv
 pacaur
 pacui


### PR DESCRIPTION
This adds VPN packages to bspwm which already exists in at least Xfce, Gnome, KDE, and Mate editions.