### PR TITLE
remove networkmanager-dispatcher-ntpd

### DIFF
--- a/community/bspwm/Packages-Desktop
+++ b/community/bspwm/Packages-Desktop
@@ -55,7 +55,6 @@ mpv
 mygtkmenui
 ncdu
 networkmanager
-networkmanager-dispatcher-ntpd
 networkmanager-dmenu
 networkmanager-openconnect
 networkmanager-openvpn

--- a/community/budgie/Packages-Desktop
+++ b/community/budgie/Packages-Desktop
@@ -75,7 +75,6 @@ nautilus-admin
 nautilus-empty-file
 netctl
 network-manager-applet
-networkmanager-dispatcher-ntpd
 networkmanager-openconnect
 networkmanager-openvpn
 networkmanager-pptp

--- a/community/cinnamon/Packages-Desktop
+++ b/community/cinnamon/Packages-Desktop
@@ -70,7 +70,6 @@ manjaro-settings-manager-notifier
 >extra nemo-python
 >extra nemo-share
 netctl
-networkmanager-dispatcher-ntpd
 networkmanager-openconnect
 networkmanager-openvpn
 networkmanager-pptp

--- a/community/deepin/Packages-Desktop
+++ b/community/deepin/Packages-Desktop
@@ -76,7 +76,6 @@ modemmanager
 >multilib lib32-mesa-demos
 netctl
 networkmanager
-networkmanager-dispatcher-ntpd
 networkmanager-openconnect
 networkmanager-openvpn
 networkmanager-pptp

--- a/community/i3/Packages-Desktop
+++ b/community/i3/Packages-Desktop
@@ -83,7 +83,6 @@ ncdu
 netctl
 networkmanager
 network-manager-applet
-networkmanager-dispatcher-ntpd
 networkmanager-openconnect
 networkmanager-openvpn
 networkmanager-pptp

--- a/community/lxde/Packages-Desktop
+++ b/community/lxde/Packages-Desktop
@@ -5,7 +5,6 @@ networkmanager-openconnect
 networkmanager-openvpn
 networkmanager-pptp
 networkmanager-vpnc
-networkmanager-dispatcher-ntpd
 nss-mdns # NSS support for mDNS (optdepend for avahi)
 ntp
 mobile-broadband-provider-info

--- a/community/lxqt/Packages-Desktop
+++ b/community/lxqt/Packages-Desktop
@@ -43,7 +43,6 @@ sddm-qt-manjaro-theme
 alsa-utils
 avahi
 networkmanager
-networkmanager-dispatcher-ntpd
 networkmanager-openconnect
 networkmanager-openvpn
 networkmanager-pptp

--- a/community/mate/Packages-Desktop
+++ b/community/mate/Packages-Desktop
@@ -67,7 +67,6 @@ usb_modeswitch
 >multilib lib32-mesa-demos
 netctl
 network-manager-applet
-networkmanager-dispatcher-ntpd
 networkmanager-openconnect
 networkmanager-openvpn
 networkmanager-pptp

--- a/manjaro/gnome/Packages-Desktop
+++ b/manjaro/gnome/Packages-Desktop
@@ -86,7 +86,6 @@ nautilus
 nautilus-admin
 nautilus-empty-file
 netctl
-networkmanager-dispatcher-ntpd
 networkmanager-openconnect
 networkmanager-openvpn
 networkmanager-pptp

--- a/manjaro/kde/Packages-Desktop
+++ b/manjaro/kde/Packages-Desktop
@@ -5,7 +5,6 @@ networkmanager-openconnect
 networkmanager-openvpn
 networkmanager-pptp
 networkmanager-vpnc
-networkmanager-dispatcher-ntpd
 nss-mdns # NSS support for mDNS (optdepend for avahi)
 ntp
 mobile-broadband-provider-info

--- a/manjaro/xfce/Packages-Desktop
+++ b/manjaro/xfce/Packages-Desktop
@@ -5,7 +5,6 @@ networkmanager-openconnect
 networkmanager-openvpn
 networkmanager-pptp
 networkmanager-vpnc
-networkmanager-dispatcher-ntpd
 nss-mdns # NSS support for mDNS (optdepend for avahi)
 ntp
 mobile-broadband-provider-info

--- a/sonar/gnome-edition/Packages-Desktop
+++ b/sonar/gnome-edition/Packages-Desktop
@@ -102,7 +102,6 @@ nautilus
 nautilus-admin
 nautilus-empty-file
 netctl
-networkmanager-dispatcher-ntpd
 networkmanager-openconnect
 networkmanager-openvpn
 networkmanager-pptp


### PR DESCRIPTION
https://forum.manjaro.org/t/intended-behaviour-regarding-ntpd/35829
This package is starting ntpd regardless of user setting in systemd and is incompatible with "set time and date automatically" from manjaro-setting-manager.