### PR TITLE
Update Packages-Live

### DIFF
--- a/shared/Packages-Live
+++ b/shared/Packages-Live
@@ -9,3 +9,4 @@ mkinitcpio-nfs-utils
 nbd
 >sonar sonar-calamares-branding
 squashfs-tools
+clonezilla


### PR DESCRIPTION
Add clonezilla to shared live packages. As requested by community https://forum.manjaro.org/t/adding-clonezilla-to-the-manjaro-live-installation-media/45762

With dependecies included, it should add about 3MiB to iso size, so probably not a big deal?