### PR TITLE
Remove DefaultPath [keep the one defined by sddm]

### DIFF
--- a/manjaro/kde/desktop-overlay/etc/sddm.conf
+++ b/manjaro/kde/desktop-overlay/etc/sddm.conf
@@ -38,9 +38,6 @@ ThemeDir=/usr/share/sddm/themes
 
 
 [Users]
-# Default $PATH
-DefaultPath=/bin:/usr/bin:/usr/local/bin
-
 # Hidden shells
 # Users with these shells as their default won't be listed
 HideShells=


### PR DESCRIPTION
see here about the problem
https://forum.manjaro.org/t/gufw-segmentation-fault/46756/14
the path order are not the same as in /etc/profile and the new way to set path in profile just append if not already in PATH then /bin was the 1st declared and caused problem.

does manjaro should use /etc/sddm.conf.d/ instead of /etc/sddm.conf??? to tweaks its sddm config.
or /usr/lib/sddm/sddm.conf.d (following devs recommendation)