### PR TITLE
Add cinnamon-translations

### DIFF
--- a/community/cinnamon/Packages-Desktop
+++ b/community/cinnamon/Packages-Desktop
@@ -9,6 +9,7 @@ binutils
 bison
 >extra blueberry
 cinnamon-sounds
+cinnamon-translations
 >extra cinnamon-wallpapers
 >extra dconf-editor
 >extra deluge


### PR DESCRIPTION
Add missing translations package because it won't be added with manjaro-settings-manager and it is specific to cinnamon.